### PR TITLE
[Optimisation, n/a] move operator aliases and logging options to the root of the migrationConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-pg-utilities",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "An opinionated set of database utilities that manage creating and connecting to a Postgres database",
   "main": "src/index.js",
   "directories": {

--- a/src/migrationConfig.js
+++ b/src/migrationConfig.js
@@ -5,9 +5,17 @@ const adapt = ({
   name: database,
   user: username,
   password,
-  options: { dialect, operatorsAliases, ...options }
+  options: { dialect, operatorsAliases, logging, ...options }
 }) => ({
-  [env]: { database, username, password, dialect, operatorsAliases, options }
+  [env]: {
+    database,
+    username,
+    password,
+    dialect,
+    operatorsAliases,
+    logging,
+    options
+  }
 })
 
 /**

--- a/src/migrationConfig.js
+++ b/src/migrationConfig.js
@@ -5,9 +5,9 @@ const adapt = ({
   name: database,
   user: username,
   password,
-  options: { dialect, ...options }
+  options: { dialect, operatorsAliases, ...options }
 }) => ({
-  [env]: { database, username, password, dialect, options }
+  [env]: { database, username, password, dialect, operatorsAliases, options }
 })
 
 /**
@@ -17,7 +17,7 @@ const adapt = ({
  * @param defaultDbName — If the database name is not set an environment variable, and if the config file does not define a database name, then use this as the database name. Optional, no default.
  * @param operatorsAliases — Sequelize recommends you don't use [operators aliases](http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-aliases), but if you want to you can set them here.  Optional, default is `false`.
  * @param logger — You can pass in a logger function here for Sequelize to use. Optional, default is `false`, meaning don't log anything.
- * @return { [env]: { database, username, password, dialect, options } }
+ * @return { [env]: { database, username, password, dialect, operatorsAliases, options } }
  */
 const migrationConfig = (config, defaultDbName, operatorsAliases, logger) =>
   adapt(configure(config, defaultDbName, operatorsAliases, logger))

--- a/test/unit/migrationConfig.spec.js
+++ b/test/unit/migrationConfig.spec.js
@@ -11,9 +11,9 @@ describe('src/migrationConfig', () => {
       database: config.test.database,
       dialect: config.test.dialect,
       operatorsAliases: false,
+      logging: false,
       options: {
         host: 'localhost',
-        logging: false,
         pool: {
           idle: 10000,
           max: 5,

--- a/test/unit/migrationConfig.spec.js
+++ b/test/unit/migrationConfig.spec.js
@@ -10,10 +10,10 @@ describe('src/migrationConfig', () => {
       password: config.test.password,
       database: config.test.database,
       dialect: config.test.dialect,
+      operatorsAliases: false,
       options: {
         host: 'localhost',
         logging: false,
-        operatorsAliases: false,
         pool: {
           idle: 10000,
           max: 5,


### PR DESCRIPTION
As per 
https://github.com/sequelize/sequelize/issues/8417#issuecomment-336179168

