### PR TITLE
[feature, #32] support optional environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ The following environment variables take precedence over whatever is defined in 
 - `DB_PORT` The database port — Defaults to `5432`
 - `DB_TYPE` The database type — Defaults to `'postgres'` — This library is written with Postgres in mind so please don't change this unless you know what you are doing.
 
+The following environment variables remain unset if they don't appear, or get set in `config/config.json`.
+
+- `DB_POOL_ACQUIRE` The database pool's `acquire` value.
+- `DB_POOL_EVICT` The database pool's `evict` value.
+
+#### Regarding `DATABASE_URL`.
+
 If you supply the `DATABASE_URL` environment variable, as Heroku and other PaaS systems generally do, then the `configure` function will extract most of what it needs from that and the extracted values will take priority over other values.
 
 ### Initialisation of a database
@@ -144,6 +151,21 @@ The `config` is an object in the form:
     dialect,
     host,
     port,
+    // optionally also pool, protocol, ssl
+    protocol,
+    pool: {
+      acquire: 20000,
+      evict: 15000,
+      min: 5,
+      max: 15,
+      idle: 10000
+    },
+    ssl: {
+      rejectUnauthorized: false,
+      ca: 'some-root-cert',
+      key: 'some-client-key',
+      cert: 'some-client-certificate'
+    }
   }
 }
 ```

--- a/src/appendOptionalPoolOptions.js
+++ b/src/appendOptionalPoolOptions.js
@@ -1,0 +1,26 @@
+const NAMES = [
+  ['DB_POOL_ACQUIRE', 'acquire'],
+  ['DB_POOL_EVICT', 'evict']
+]
+
+const appendOptionalPoolOptions = config => {
+  console.log('config.pool', config.pool)
+
+  const append = (acc, [e, n]) =>
+    process.env[e] || config.pool[n]
+      ? {
+          ...acc,
+          [n]: Number(process.env[e] || config.pool[n])
+        }
+      : acc
+
+  return pool =>
+    config.pool
+      ? {
+          ...pool,
+          ...NAMES.reduce(append, config.pool)
+        }
+      : pool
+}
+
+module.exports = appendOptionalPoolOptions

--- a/src/configure.js
+++ b/src/configure.js
@@ -7,6 +7,7 @@
 
 const env = require('./env')
 const urlParser = require('./urlParser')
+const appendOptionalPoolOptions = require('./appendOptionalPoolOptions')
 
 /**
  * Generate a Sequelize configuration object using a mix of environment variables,
@@ -49,14 +50,17 @@ const configure = (
         idle: process.env.DB_POOL_IDLE || 10000
       }
 
+  const appendPoolOptions = appendOptionalPoolOptions(config)
+
   const options = {
     host: parsedUrl.host || process.env.DB_HOST || config.host || 'localhost',
     port: parsedUrl.port || process.env.DB_PORT || config.port || 5432,
     dialect:
       parsedUrl.dialect || process.env.DB_TYPE || config.dialect || 'postgres',
-    pool: poolOptions,
-    logging: logger // this can be a logging function.
+    logging: logger, // this can be a logging function.
+    pool: appendPoolOptions(poolOptions)
   }
+
   // see https://github.com/sequelize/sequelize/issues/8417
   // see also https://github.com/sequelize/sequelize/issues/8417#issuecomment-461150731
   if (operatorsAliases !== undefined)

--- a/test/fixtures/config-with-pool.aquire.json
+++ b/test/fixtures/config-with-pool.aquire.json
@@ -1,0 +1,12 @@
+{
+  "test": {
+    "username": "test",
+    "password": "testing",
+    "database": "no-such-database",
+    "host": "localhost",
+    "dialect": "postgres",
+    "pool": {
+      "acquire": 20000
+    }
+  }
+}

--- a/test/unit/configure.test.js
+++ b/test/unit/configure.test.js
@@ -3,6 +3,7 @@ const { expect } = require('chai')
 const { configure } = require('../../src')
 const configWithoutSSL = require('../fixtures/config-without-ssl.json')
 const configWithSSL = require('../fixtures/config-with-ssl.json')
+const configWithAquire = require('../fixtures/config-with-pool.aquire.json')
 
 describe('src/configure', () => {
   const makeExpected = (config, operatorsAliases) => {
@@ -15,6 +16,7 @@ describe('src/configure', () => {
         port: 5432,
         dialect: 'postgres',
         pool: {
+          ...(config.test.pool || {}),
           min: 1,
           max: 5,
           idle: 10000
@@ -62,6 +64,18 @@ describe('src/configure', () => {
 
     before(() => {
       result = configure(configWithSSL, undefined, false)
+    })
+
+    it('returns the expected result', () => {
+      expect(result).to.deep.equal(expected)
+    })
+  })
+
+  context('with pool.aquire', () => {
+    const expected = makeExpected(configWithAquire, false)
+
+    before(() => {
+      result = configure(configWithAquire, undefined, false)
     })
 
     it('returns the expected result', () => {


### PR DESCRIPTION
added support for the following optional environment variables

- `DB_POOL_ACQUIRE` The database pool's `acquire` value.
- `DB_POOL_EVICT` The database pool's `evict` value.

also

- `config.pool.acquire`
- `config.pool.evict`
