### PR TITLE
[feature, #32] support additional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,26 @@ They each accept the following parameters.
 - `defaultDbName`: If the database name is not set in an environment variable, and if the config file does not define a database name, then use this as the database name. Optional, no default.
 - `operatorsAliases`: Sequelize recommends you don't use [operators aliases](http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-aliases), but if you want to you can set them here. If you are using Sequelize 4 or older then you need to set this to `false` but if you are using Sequelize 5 or better you ought to just ignore this option. ([more information](https://github.com/sequelize/sequelize/issues/8417#issuecomment-461150731))
 - `logger`: You can pass in a logger function here for Sequelize to use. Optional, default is `false`, meaning don't log anything. This gets returned as `logging` in the configs.
+- `options`: optional additional options that are passed through to sequelize.
+
+  These match to the options listed at [sequelize/sequelize/lib/sequelize.js#126](https://github.com/sequelize/sequelize/blob/master/lib/sequelize.js#L126), which at the time of this writing are:
+
+  - `dialectModule`,
+  - `dialectModulePath`,
+  - `define`,
+  - `query`,
+  - `schema`,
+  - `set`,
+  - `sync`,
+  - `quoteIdentifiers`,
+  - `transactionType`,
+  - `typeValidation`,
+  - `hooks`,
+  - `pool.validate`,
+  - `retry.match`,
+  - `retry.max`
+
+  Other additional options are ignored.
 
 ### SSL Options
 

--- a/src/appendOptionalPoolOptions.js
+++ b/src/appendOptionalPoolOptions.js
@@ -3,9 +3,7 @@ const NAMES = [
   ['DB_POOL_EVICT', 'evict']
 ]
 
-const appendOptionalPoolOptions = config => {
-  console.log('config.pool', config.pool)
-
+const appendOptionalPoolOptions = (config, also = {}) => {
   const append = (acc, [e, n]) =>
     process.env[e] || config.pool[n]
       ? {
@@ -18,9 +16,10 @@ const appendOptionalPoolOptions = config => {
     config.pool
       ? {
           ...pool,
+          ...also,
           ...NAMES.reduce(append, config.pool)
         }
-      : pool
+      : { ...pool, ...also }
 }
 
 module.exports = appendOptionalPoolOptions

--- a/src/configure.js
+++ b/src/configure.js
@@ -8,6 +8,8 @@
 const env = require('./env')
 const urlParser = require('./urlParser')
 const appendOptionalPoolOptions = require('./appendOptionalPoolOptions')
+const { PROGRAMATIC_OPTIONS } = require('./constants')
+const onlyDefined = require('./onlyDefined')
 
 /**
  * Generate a Sequelize configuration object using a mix of environment variables,
@@ -17,13 +19,19 @@ const appendOptionalPoolOptions = require('./appendOptionalPoolOptions')
  * @param defaultDbName — If the database name is not set an environment variable, and if the config file does not define a database name, then use this as the database name. Optional, no default.
  * @param operatorsAliases — Sequelize recommends you don't use [operators aliases](http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-aliases), but if you want to you can set them here.  Optional, default is `false`.
  * @param logger — You can pass in a logger function here for Sequelize to use. Optional, default is `false`, meaning don't log anything.
+ * @param options — You can pass in additional options here. Optional.
  * @return { name, user, password, options }
  */
 const configure = (
   { [env]: config },
   defaultDbName,
   operatorsAliases,
-  logger = false
+  logger = false,
+  {
+    pool: { validate } = {},
+    retry: { match, max } = {},
+    ...additionalOptions
+  } = {}
 ) => {
   const parsedUrl = urlParser(process.env.DATABASE_URL)
 
@@ -50,7 +58,7 @@ const configure = (
         idle: process.env.DB_POOL_IDLE || 10000
       }
 
-  const appendPoolOptions = appendOptionalPoolOptions(config)
+  const appendPoolOptions = appendOptionalPoolOptions(config, { validate })
 
   const options = {
     host: parsedUrl.host || process.env.DB_HOST || config.host || 'localhost',
@@ -74,8 +82,15 @@ const configure = (
     options.dialectOptions = { ssl: config.ssl }
     options.ssl = true
   }
+  if (match) options.retry = { ...(options.retry || {}), match }
+  if (max) options.retry = { ...(options.retry || {}), max }
 
-  return { name, user, password, options }
+  // only allow whitelisted additional options.
+  PROGRAMATIC_OPTIONS.forEach(key => {
+    options[key] = additionalOptions[key]
+  })
+
+  return onlyDefined({ name, user, password, options })
 }
 
 module.exports = configure

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,21 @@
+// see https://github.com/sequelize/sequelize/blob/master/lib/sequelize.js#L126
+const PROGRAMATIC_OPTIONS = [
+  'dialectModule',
+  'dialectModulePath',
+  'define',
+  'query',
+  'schema',
+  'set',
+  'sync',
+  'quoteIdentifiers',
+  'transactionType',
+  'typeValidation',
+  'hooks'
+]
+
+const MAX_RETRIES = 5
+
+module.exports = {
+  PROGRAMATIC_OPTIONS,
+  MAX_RETRIES
+}

--- a/src/makeInitialiser.js
+++ b/src/makeInitialiser.js
@@ -3,8 +3,7 @@ const pgtools = require('pgtools')
 const sleep = require('./sleep')
 const configure = require('./configure')
 const env = require('./env')
-
-const MAX_RETRIES = 5
+const { MAX_RETRIES } = require('./constants')
 
 /**
  * Create a database initialisation function that uses `pgtools` to attempt to create
@@ -14,15 +13,22 @@ const MAX_RETRIES = 5
  * @param defaultDbName — If the database name is not set an environment variable, and if the config file does not define a database name, then use this as the database name. Optional, no default.
  * @param operatorsAliases — Sequelize recommends you don't use [operators aliases](http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-aliases), but if you want to you can set them here.  Optional, default is `false`.
  * @param logger — You can pass in a logger function here for Sequelize to use. Optional, default is `false`, meaning don't log anything.
+ * @param options — You can pass in additional options here. Optional.
  * @return an async function that initialises the database.
  */
-const makeInitialiser = (config, defaultDbName, operatorsAliases, logger) => {
+const makeInitialiser = (
+  config,
+  defaultDbName,
+  operatorsAliases,
+  logger,
+  options
+) => {
   const {
     name,
     user,
     password,
     options: { port, host }
-  } = configure(config, defaultDbName, operatorsAliases, logger)
+  } = configure(config, defaultDbName, operatorsAliases, logger, options)
 
   const dbConfig = { user, password, port, host }
 

--- a/src/migrationConfig.js
+++ b/src/migrationConfig.js
@@ -31,9 +31,15 @@ const adapt = ({
  * @param defaultDbName — If the database name is not set an environment variable, and if the config file does not define a database name, then use this as the database name. Optional, no default.
  * @param operatorsAliases — Sequelize recommends you don't use [operators aliases](http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-aliases), but if you really want to you can set them here.
  * @param logger — You can pass in a logger function here for Sequelize to use. Optional, default is `false`, meaning don't log anything.
+ * @param options — You can pass in additional options here. Optional.
  * @return { [env]: { database, username, password, dialect, dialectOptions, [operatorsAliases]? } }
  */
-const migrationConfig = (config, defaultDbName, operatorsAliases, logger) =>
-  adapt(configure(config, defaultDbName, operatorsAliases, logger))
+const migrationConfig = (
+  config,
+  defaultDbName,
+  operatorsAliases,
+  logger,
+  options
+) => adapt(configure(config, defaultDbName, operatorsAliases, logger, options))
 
 module.exports = migrationConfig

--- a/src/onlyDefined.js
+++ b/src/onlyDefined.js
@@ -1,0 +1,19 @@
+const noUndefined = value => value !== undefined
+
+const onlyDefined = data =>
+  typeof data === 'object' && data !== null
+    ? Object.keys(data).reduce((acc, elem) => {
+        const value = data[elem]
+        if (value !== undefined) {
+          if (Array.isArray(value))
+            acc[elem] = value.map(onlyDefined).filter(noUndefined)
+          else if (typeof value === 'object') {
+            const fValue = onlyDefined(value)
+            if (Object.keys(fValue).length) acc[elem] = fValue
+          } else acc[elem] = value
+        }
+        return acc
+      }, {})
+    : data
+
+module.exports = onlyDefined

--- a/test/unit/appendOptionalPoolOptions.test.js
+++ b/test/unit/appendOptionalPoolOptions.test.js
@@ -1,0 +1,34 @@
+const { expect } = require('chai')
+
+const appendOptionalPoolOptions = require('../../src/appendOptionalPoolOptions')
+
+const config = {
+  pool: { acquire: 5000 }
+}
+
+const pool = {
+  something: 'wheee'
+}
+
+describe('src/appendOptionalPoolOptions', () => {
+  context('when there are extra options', () => {
+    const extra = { some: 'extra' }
+
+    it('appends the extra options', () => {
+      expect(appendOptionalPoolOptions(config, extra)(pool)).to.deep.equal({
+        ...pool,
+        ...config.pool,
+        ...extra
+      })
+    })
+  })
+
+  context('when there are no extra options', () => {
+    it('returns the original options', () => {
+      expect(appendOptionalPoolOptions(config)(pool)).to.deep.equal({
+        ...pool,
+        ...config.pool
+      })
+    })
+  })
+})

--- a/test/unit/configure.test.js
+++ b/test/unit/configure.test.js
@@ -1,6 +1,8 @@
 const { expect } = require('chai')
 
 const { configure } = require('../../src')
+const { PROGRAMATIC_OPTIONS } = require('../../src/constants')
+
 const configWithoutSSL = require('../fixtures/config-without-ssl.json')
 const configWithSSL = require('../fixtures/config-with-ssl.json')
 const configWithAquire = require('../fixtures/config-with-pool.aquire.json')
@@ -30,6 +32,8 @@ describe('src/configure', () => {
       res.options.dialectOptions = { ssl: config.test.ssl }
       res.options.ssl = true
     }
+    if (config.test.retry) res.options.retry = config.test.retry
+
     return res
   }
 
@@ -81,5 +85,57 @@ describe('src/configure', () => {
     it('returns the expected result', () => {
       expect(result).to.deep.equal(expected)
     })
+  })
+
+  context('with retry.max', () => {
+    const max = 5
+    const retry = { max }
+    const base = makeExpected(configWithoutSSL, false)
+
+    const expected = {
+      ...base,
+      options: {
+        ...base.options,
+        retry
+      }
+    }
+
+    before(() => {
+      result = configure(configWithoutSSL, undefined, false, undefined, {
+        retry
+      })
+    })
+
+    it('returns the expected result', () => {
+      expect(result).to.deep.equal(expected)
+    })
+  })
+
+  context('with additional options', () => {
+    const doTest = optionName => {
+      context(`with additional option ${optionName}`, () => {
+        const base = makeExpected(configWithoutSSL, false)
+
+        const expected = {
+          ...base,
+          options: {
+            ...base.options,
+            [optionName]: optionName
+          }
+        }
+
+        before(() => {
+          result = configure(configWithoutSSL, undefined, false, undefined, {
+            [optionName]: optionName
+          })
+        })
+
+        it('returns the expected result', () => {
+          expect(result).to.deep.equal(expected)
+        })
+      })
+    }
+
+    PROGRAMATIC_OPTIONS.forEach(doTest)
   })
 })

--- a/test/unit/onlyDefined.test.js
+++ b/test/unit/onlyDefined.test.js
@@ -1,0 +1,25 @@
+const { expect } = require('chai')
+
+const onlyDefined = require('../../src/onlyDefined')
+
+const original = {
+  array: [
+    { inner: 'w00t!', however: undefined },
+    undefined,
+    { outer: 'huzzah!' }
+  ],
+  here: 'is okay',
+  test: undefined,
+  otherTest: { nah: undefined }
+}
+
+const expected = {
+  array: [{ inner: 'w00t!' }, original.array[2]],
+  here: original.here
+}
+
+describe('src/onlyDefined', () => {
+  it('returns the expected result', () => {
+    expect(onlyDefined(original)).to.deep.equal(expected)
+  })
+})


### PR DESCRIPTION
supports providing the following programmatic options

  - `dialectModule`,
  - `dialectModulePath`,
  - `define`,
  - `query`,
  - `schema`,
  - `set`,
  - `sync`,
  - `quoteIdentifiers`,
  - `transactionType`,
  - `typeValidation`,
  - `hooks`,
  - `pool.validate`,
  - `retry.match`,
  - `retry.max`
