### PR TITLE
[feature, #32] added final config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,11 @@ The `config` is an object in the form:
     dialect,
     host,
     port,
-    // optionally also pool, protocol, ssl
+    // optionally also the following
+    benchmark,
+    clientMinMessages,
+    native,
+    omitNull,
     protocol,
     pool: {
       acquire: 20000,
@@ -160,12 +164,14 @@ The `config` is an object in the form:
       max: 15,
       idle: 10000
     },
+    replication,
     ssl: {
       rejectUnauthorized: false,
       ca: 'some-root-cert',
       key: 'some-client-key',
       cert: 'some-client-certificate'
-    }
+    },
+    timezone,
   }
 }
 ```

--- a/src/configure.js
+++ b/src/configure.js
@@ -8,7 +8,7 @@
 const env = require('./env')
 const urlParser = require('./urlParser')
 const appendOptionalPoolOptions = require('./appendOptionalPoolOptions')
-const { PROGRAMATIC_OPTIONS } = require('./constants')
+const { CONFIG_OPTIONS, PROGRAMATIC_OPTIONS } = require('./constants')
 const onlyDefined = require('./onlyDefined')
 
 /**
@@ -65,18 +65,18 @@ const configure = (
     port: parsedUrl.port || process.env.DB_PORT || config.port || 5432,
     dialect:
       parsedUrl.dialect || process.env.DB_TYPE || config.dialect || 'postgres',
-    logging: logger, // this can be a logging function.
+    logging: logger, // this can be a logging function or false.
     pool: appendPoolOptions(poolOptions)
   }
+  // only allow whitelisted additional config.
+  CONFIG_OPTIONS.forEach(key => {
+    options[key] = config[key]
+  })
 
   // see https://github.com/sequelize/sequelize/issues/8417
   // see also https://github.com/sequelize/sequelize/issues/8417#issuecomment-461150731
   if (operatorsAliases !== undefined)
     options.operatorsAliases = operatorsAliases
-
-  /* istanbul ignore if */
-  if (process.env.DATABASE_URL)
-    options.protocol = parsedUrl.protocol || config.protocol
 
   if (config.ssl) {
     options.dialectOptions = { ssl: config.ssl }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,21 +1,40 @@
 // see https://github.com/sequelize/sequelize/blob/master/lib/sequelize.js#L126
+// ref also https://github.com/davesag/sequelize-pg-utilities/issues/32
+
+const CONFIG_OPTIONS = [
+  'benchmark',
+  'clientMinMessages',
+  'native',
+  'omitNull',
+  'protocol',
+  'replication',
+  'timezone'
+]
+
 const PROGRAMATIC_OPTIONS = [
+  'define',
   'dialectModule',
   'dialectModulePath',
-  'define',
+  'hooks',
+  'logQueryParameters',
+  'minifyAliases',
   'query',
+  'quoteIdentifiers',
   'schema',
   'set',
   'sync',
-  'quoteIdentifiers',
   'transactionType',
-  'typeValidation',
-  'hooks'
+  'typeValidation'
 ]
+
+// note: Do not use the following as an option:
+// - standardConformingStrings,
+// - quoteIdentifiers
 
 const MAX_RETRIES = 5
 
 module.exports = {
+  CONFIG_OPTIONS,
   PROGRAMATIC_OPTIONS,
   MAX_RETRIES
 }

--- a/src/urlParser.js
+++ b/src/urlParser.js
@@ -12,8 +12,7 @@ const urlParser = dbUrl => {
     host,
     port,
     database: pathname.substring(1),
-    dialect: POSTGRES,
-    protocol: POSTGRES
+    dialect: POSTGRES
   }
 }
 

--- a/test/unit/configure.test.js
+++ b/test/unit/configure.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai')
 
 const { configure } = require('../../src')
-const { PROGRAMATIC_OPTIONS } = require('../../src/constants')
+const { CONFIG_OPTIONS, PROGRAMATIC_OPTIONS } = require('../../src/constants')
 
 const configWithoutSSL = require('../fixtures/config-without-ssl.json')
 const configWithSSL = require('../fixtures/config-with-ssl.json')
@@ -113,17 +113,17 @@ describe('src/configure', () => {
 
   context('with additional options', () => {
     const doTest = optionName => {
-      context(`with additional option ${optionName}`, () => {
-        const base = makeExpected(configWithoutSSL, false)
+      const base = makeExpected(configWithoutSSL, false)
 
-        const expected = {
-          ...base,
-          options: {
-            ...base.options,
-            [optionName]: optionName
-          }
+      const expected = {
+        ...base,
+        options: {
+          ...base.options,
+          [optionName]: optionName
         }
+      }
 
+      context(`with additional option ${optionName}`, () => {
         before(() => {
           result = configure(configWithoutSSL, undefined, false, undefined, {
             [optionName]: optionName
@@ -137,5 +137,37 @@ describe('src/configure', () => {
     }
 
     PROGRAMATIC_OPTIONS.forEach(doTest)
+  })
+
+  context('with additional config', () => {
+    const doTest = optionName => {
+      const config = {
+        test: {
+          ...configWithoutSSL.test,
+          [optionName]: optionName
+        }
+      }
+      const base = makeExpected(configWithoutSSL)
+
+      const expected = {
+        ...base,
+        options: {
+          ...base.options,
+          [optionName]: optionName
+        }
+      }
+
+      context(`with additional config ${optionName}`, () => {
+        before(() => {
+          result = configure(config)
+        })
+
+        it('returns the expected result', () => {
+          expect(result).to.deep.equal(expected)
+        })
+      })
+    }
+
+    CONFIG_OPTIONS.forEach(doTest)
   })
 })

--- a/test/unit/urlParser.test.js
+++ b/test/unit/urlParser.test.js
@@ -11,8 +11,7 @@ describe('src/urlParser', () => {
     password: 'aic5oO6Cran1g3hk6mJa5QqNZB',
     host: 'ec2-23-21-91-97.compute-1.amazonaws.com',
     port: '5432',
-    dialect: 'postgres',
-    protocol: 'postgres'
+    dialect: 'postgres'
   }
 
   it('parses an Heroku style database url', () => {


### PR DESCRIPTION
added config file support for the following options

- `benchmark`,
- `clientMinMessages`,
- `native`,
- `omitNull`,
- `protocol`,
- `replication`,
- `timezone`

Removed `protocol` from the `urlParser` as the value it was returning was just wrong.

