### PR TITLE
[feature, #35] remove operatorsAliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ They each accept the following parameters.
   ```
 
 - `defaultDbName`: If the database name is not set in an environment variable, and if the config file does not define a database name, then use this as the database name. Optional, no default.
-- `operatorsAliases`: Sequelize recommends you don't use [operators aliases](http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-aliases), but if you want to you can set them here. If you are using Sequelize 4 or older then you need to set this to `false` but if you are using Sequelize 5 or better you ought to just ignore this option. ([more information](https://github.com/sequelize/sequelize/issues/8417#issuecomment-461150731))
 - `logger`: You can pass in a logger function here for Sequelize to use. Optional, default is `false`, meaning don't log anything. This gets returned as `logging` in the configs.
 - `options`: optional additional configuration that is passed through to Sequelize.
 

--- a/src/configure.js
+++ b/src/configure.js
@@ -17,7 +17,6 @@ const onlyDefined = require('./onlyDefined')
  *
  * @param config — The content of the `config/config.json` file. Required, no default.
  * @param defaultDbName — If the database name is not set an environment variable, and if the config file does not define a database name, then use this as the database name. Optional, no default.
- * @param operatorsAliases — Sequelize recommends you don't use [operators aliases](http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-aliases), but if you want to you can set them here.  Optional, default is `false`.
  * @param logger — You can pass in a logger function here for Sequelize to use. Optional, default is `false`, meaning don't log anything.
  * @param options — You can pass in additional options here. Optional.
  * @return { name, user, password, options }
@@ -25,7 +24,6 @@ const onlyDefined = require('./onlyDefined')
 const configure = (
   { [env]: config },
   defaultDbName,
-  operatorsAliases,
   logger = false,
   {
     pool: { validate } = {},
@@ -72,11 +70,6 @@ const configure = (
   CONFIG_OPTIONS.forEach(key => {
     options[key] = config[key]
   })
-
-  // see https://github.com/sequelize/sequelize/issues/8417
-  // see also https://github.com/sequelize/sequelize/issues/8417#issuecomment-461150731
-  if (operatorsAliases !== undefined)
-    options.operatorsAliases = operatorsAliases
 
   if (config.ssl) {
     options.dialectOptions = { ssl: config.ssl }

--- a/src/makeInitialiser.js
+++ b/src/makeInitialiser.js
@@ -11,24 +11,17 @@ const { MAX_RETRIES } = require('./constants')
  *
  * @param config — The content of the `config/config.json` file. Required, no default.
  * @param defaultDbName — If the database name is not set an environment variable, and if the config file does not define a database name, then use this as the database name. Optional, no default.
- * @param operatorsAliases — Sequelize recommends you don't use [operators aliases](http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-aliases), but if you want to you can set them here.  Optional, default is `false`.
  * @param logger — You can pass in a logger function here for Sequelize to use. Optional, default is `false`, meaning don't log anything.
  * @param options — You can pass in additional options here. Optional.
  * @return an async function that initialises the database.
  */
-const makeInitialiser = (
-  config,
-  defaultDbName,
-  operatorsAliases,
-  logger,
-  options
-) => {
+const makeInitialiser = (config, defaultDbName, logger, options) => {
   const {
     name,
     user,
     password,
     options: { port, host }
-  } = configure(config, defaultDbName, operatorsAliases, logger, options)
+  } = configure(config, defaultDbName, logger, options)
 
   const dbConfig = { user, password, port, host }
 

--- a/src/migrationConfig.js
+++ b/src/migrationConfig.js
@@ -5,7 +5,7 @@ const adapt = ({
   name: database,
   user: username,
   password,
-  options: { dialect, dialectOptions, host, port, ssl, operatorsAliases }
+  options: { dialect, dialectOptions, host, port, ssl }
 }) => {
   const adapted = {
     [env]: {
@@ -17,10 +17,10 @@ const adapt = ({
       port
     }
   }
-  if (operatorsAliases !== undefined)
-    adapted[env].operatorsAliases = operatorsAliases
+
   if (dialectOptions) adapted[env].dialectOptions = dialectOptions
   if (ssl) adapted[env].ssl = ssl
+
   return adapted
 }
 
@@ -29,17 +29,11 @@ const adapt = ({
  *
  * @param config — The content of the `config/config.json` file. Required, no default.
  * @param defaultDbName — If the database name is not set an environment variable, and if the config file does not define a database name, then use this as the database name. Optional, no default.
- * @param operatorsAliases — Sequelize recommends you don't use [operators aliases](http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-aliases), but if you really want to you can set them here.
  * @param logger — You can pass in a logger function here for Sequelize to use. Optional, default is `false`, meaning don't log anything.
  * @param options — You can pass in additional options here. Optional.
- * @return { [env]: { database, username, password, dialect, dialectOptions, [operatorsAliases]? } }
+ * @return { [env]: { database, username, password, dialect, dialectOptions } }
  */
-const migrationConfig = (
-  config,
-  defaultDbName,
-  operatorsAliases,
-  logger,
-  options
-) => adapt(configure(config, defaultDbName, operatorsAliases, logger, options))
+const migrationConfig = (config, defaultDbName, logger, options) =>
+  adapt(configure(config, defaultDbName, logger, options))
 
 module.exports = migrationConfig

--- a/test/unit/configure.test.js
+++ b/test/unit/configure.test.js
@@ -8,7 +8,7 @@ const configWithSSL = require('../fixtures/config-with-ssl.json')
 const configWithAquire = require('../fixtures/config-with-pool.aquire.json')
 
 describe('src/configure', () => {
-  const makeExpected = (config, operatorsAliases) => {
+  const makeExpected = config => {
     const res = {
       name: config.test.database,
       user: config.test.username,
@@ -26,8 +26,7 @@ describe('src/configure', () => {
         logging: false
       }
     }
-    if (operatorsAliases !== undefined)
-      res.options.operatorsAliases = operatorsAliases
+
     if (config.test.ssl) {
       res.options.dialectOptions = { ssl: config.test.ssl }
       res.options.ssl = true
@@ -63,18 +62,6 @@ describe('src/configure', () => {
     })
   })
 
-  context('with operatorsAliases', () => {
-    const expected = makeExpected(configWithSSL, false)
-
-    before(() => {
-      result = configure(configWithSSL, undefined, false)
-    })
-
-    it('returns the expected result', () => {
-      expect(result).to.deep.equal(expected)
-    })
-  })
-
   context('with pool.aquire', () => {
     const expected = makeExpected(configWithAquire, false)
 
@@ -90,7 +77,7 @@ describe('src/configure', () => {
   context('with retry.max', () => {
     const max = 5
     const retry = { max }
-    const base = makeExpected(configWithoutSSL, false)
+    const base = makeExpected(configWithoutSSL)
 
     const expected = {
       ...base,
@@ -101,7 +88,7 @@ describe('src/configure', () => {
     }
 
     before(() => {
-      result = configure(configWithoutSSL, undefined, false, undefined, {
+      result = configure(configWithoutSSL, undefined, undefined, {
         retry
       })
     })
@@ -113,7 +100,7 @@ describe('src/configure', () => {
 
   context('with additional options', () => {
     const doTest = optionName => {
-      const base = makeExpected(configWithoutSSL, false)
+      const base = makeExpected(configWithoutSSL)
 
       const expected = {
         ...base,
@@ -125,7 +112,7 @@ describe('src/configure', () => {
 
       context(`with additional option ${optionName}`, () => {
         before(() => {
-          result = configure(configWithoutSSL, undefined, false, undefined, {
+          result = configure(configWithoutSSL, undefined, undefined, {
             [optionName]: optionName
           })
         })

--- a/test/unit/makeInitialiser.test.js
+++ b/test/unit/makeInitialiser.test.js
@@ -55,7 +55,7 @@ describe('src/makeInitialiser', () => {
         './sleep': sleep
       })
 
-      init = makeInitialiser(config, undefined, undefined, logger)
+      init = makeInitialiser(config, undefined, logger)
     })
 
     context('succeeds', () => {

--- a/test/unit/migrationConfig.test.js
+++ b/test/unit/migrationConfig.test.js
@@ -5,7 +5,7 @@ const configWithoutSSL = require('../fixtures/config-without-ssl.json')
 const configWithSSL = require('../fixtures/config-with-ssl.json')
 
 describe('src/migrationConfig', () => {
-  const makeExpected = (config, operatorsAliases) => {
+  const makeExpected = config => {
     const res = {
       test: {
         username: config.test.username,
@@ -20,8 +20,7 @@ describe('src/migrationConfig', () => {
       res.test.dialectOptions = { ssl: config.test.ssl }
       res.test.ssl = true
     }
-    if (operatorsAliases !== undefined)
-      res.test.operatorsAliases = operatorsAliases
+
     return res
   }
 
@@ -44,19 +43,6 @@ describe('src/migrationConfig', () => {
 
     before(() => {
       result = migrationConfig(configWithSSL)
-    })
-
-    it('gave the expected result', () => {
-      expect(result).to.deep.equal(expected)
-    })
-  })
-
-  context('with operatorsAliases', () => {
-    const operatorsAliases = ['some', 'operators', 'aliases']
-    const expected = makeExpected(configWithSSL, operatorsAliases)
-
-    before(() => {
-      result = migrationConfig(configWithSSL, undefined, operatorsAliases)
     })
 
     it('gave the expected result', () => {


### PR DESCRIPTION
In line with the [advice in the sequelize documentation](https://sequelize.org/master/manual/model-querying-basics.html) I have removed `operatorsAliases`. If you really need them do not upgrade.

