### PR TITLE
[feature, #30] replace pgtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ This library assumes:
 
 ## Install
 
-Add `sequelize-pg-utilities` as a dependency:
+Add `sequelize-pg-utilities` and [`pg`](https://github.com/brianc/node-postgres/tree/master/packages/pg) as dependencies:
 
 ```sh
-npm i sequelize-pg-utilities
+npm i pg sequelize-pg-utilities
 ```
 
-`sequelize-pg-utilities` has one dependency.
+**Note**: `pg` is a peer-dependency of `sequelize-pg-utilities`.
 
-- [`pgtools`](https://www.npmjs.com/package/pgtools)
+-
 
 ## Usage Scenarios
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2003,7 +2003,8 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -2216,11 +2217,6 @@
         }
       }
     },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
@@ -2351,11 +2347,6 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "buffer-writer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
-      "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg="
-    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -2400,11 +2391,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
-    },
-    "camelcase": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
     },
     "chai": {
       "version": "4.2.0",
@@ -2618,6 +2604,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
@@ -2628,6 +2615,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2636,6 +2624,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2646,6 +2635,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2670,7 +2660,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
@@ -2839,7 +2830,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decompress-response": {
       "version": "6.0.0",
@@ -3121,6 +3113,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -3908,15 +3901,6 @@
         }
       }
     },
-    "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
-    },
     "find-versions": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
@@ -4068,21 +4052,11 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "generic-pool": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz",
-      "integrity": "sha1-eAw29p360FpaBF3Te+etyhGk9v8="
-    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
       "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
       "dev": true
-    },
-    "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -4235,7 +4209,8 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -4317,7 +4292,8 @@
     "hosted-git-info": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
+      "dev": true
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -4704,7 +4680,8 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
     },
     "ip": {
       "version": "1.1.5",
@@ -4727,7 +4704,8 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -4897,11 +4875,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -5091,11 +5064,6 @@
         "iterate-iterator": "^1.0.1"
       }
     },
-    "js-string-escape": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5221,6 +5189,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
       "requires": {
         "invert-kv": "^1.0.0"
       }
@@ -5432,7 +5401,8 @@
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
     },
     "lodash.assignin": {
       "version": "4.2.0",
@@ -6349,6 +6319,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -6380,7 +6351,8 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nyc": {
       "version": "15.1.0",
@@ -6722,6 +6694,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
       "requires": {
         "lcid": "^1.0.0"
       }
@@ -6982,11 +6955,6 @@
         }
       }
     },
-    "packet-reader": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
-      "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
-    },
     "pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -7006,6 +6974,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -7017,14 +6986,6 @@
       "dev": true,
       "requires": {
         "xtend": "~4.0.1"
-      }
-    },
-    "path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "requires": {
-        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -7042,7 +7003,8 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "1.8.0",
@@ -7087,75 +7049,98 @@
         "through2": "^2.0.3"
       }
     },
-    "pg-connection-string": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
-    },
-    "pg-types": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
-      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
+    "pg": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.3.0.tgz",
+      "integrity": "sha512-jQPKWHWxbI09s/Z9aUvoTbvGgoj98AU7FDCcQ7kdejupn/TcNpx56v2gaOTzXkzOajmOEJEdi9eTh9cA2RVAjQ==",
+      "dev": true,
       "requires": {
-        "postgres-array": "~1.0.0",
-        "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.0",
-        "postgres-interval": "^1.1.0"
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.3.0",
+        "pg-pool": "^3.2.1",
+        "pg-protocol": "^1.2.5",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x",
+        "semver": "4.3.2"
+      },
+      "dependencies": {
+        "buffer-writer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+          "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+          "dev": true
+        },
+        "packet-reader": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+          "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
+          "dev": true
+        },
+        "pg-connection-string": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.3.0.tgz",
+          "integrity": "sha512-ukMTJXLI7/hZIwTW7hGMZJ0Lj0S2XQBCJ4Shv4y1zgQ/vqVea+FLhzywvPj0ujSuofu+yA4MYHGZPTsgjBgJ+w==",
+          "dev": true
+        },
+        "pg-types": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+          "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+          "dev": true,
+          "requires": {
+            "pg-int8": "1.0.1",
+            "postgres-array": "~2.0.0",
+            "postgres-bytea": "~1.0.0",
+            "postgres-date": "~1.0.4",
+            "postgres-interval": "^1.1.0"
+          }
+        },
+        "postgres-array": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+          "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+          "dev": true
+        },
+        "postgres-date": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.5.tgz",
+          "integrity": "sha512-pdau6GRPERdAYUQwkBnGKxEfPyhVZXG/JiS44iZWiNdSOWE09N2lUgN6yshuq6fVSon4Pm0VMXd1srUUkLe9iA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
+          "dev": true
+        }
       }
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true
+    },
+    "pg-pool": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.1.tgz",
+      "integrity": "sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA==",
+      "dev": true
+    },
+    "pg-protocol": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.5.tgz",
+      "integrity": "sha512-1uYCckkuTfzz/FCefvavRywkowa6M5FohNMF5OjKrqo9PSR8gYc8poVmwwYQaBxhmQdBjhtP514eXy9/Us2xKg==",
+      "dev": true
     },
     "pgpass": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
       "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "dev": true,
       "requires": {
         "split": "^1.0.0"
-      }
-    },
-    "pgtools": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/pgtools/-/pgtools-0.3.0.tgz",
-      "integrity": "sha512-8NxDCJ8xJ6hOp9hVNZqxi+TZl7hM1Jc8pQyj8DlAbyaWnk5OsGwf3gB/UyDODdOguiim9QzbzPsslp//apO+Uw==",
-      "requires": {
-        "bluebird": "^3.3.5",
-        "pg": "^6.1.0",
-        "pg-connection-string": "^0.1.3",
-        "yargs": "^5.0.0"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
-        },
-        "pg": {
-          "version": "6.4.2",
-          "resolved": "https://registry.npmjs.org/pg/-/pg-6.4.2.tgz",
-          "integrity": "sha1-w2QBEGDqx6UHoq4GPrhX7OkQ4n8=",
-          "requires": {
-            "buffer-writer": "1.0.1",
-            "js-string-escape": "1.0.1",
-            "packet-reader": "0.3.1",
-            "pg-connection-string": "0.1.3",
-            "pg-pool": "1.*",
-            "pg-types": "1.*",
-            "pgpass": "1.*",
-            "semver": "4.3.2"
-          }
-        },
-        "pg-pool": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.8.0.tgz",
-          "integrity": "sha1-9+xzgkw3oD8Hb1G/33DjQBR8Tzc=",
-          "requires": {
-            "generic-pool": "2.4.3",
-            "object-assign": "4.1.0"
-          }
-        },
-        "semver": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
-        }
       }
     },
     "picomatch": {
@@ -7167,20 +7152,8 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
     },
     "pkg-dir": {
       "version": "2.0.0",
@@ -7217,25 +7190,17 @@
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
-    "postgres-array": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz",
-      "integrity": "sha1-jgsy6wO/d6XAp4UeBEHBaaJWojg="
-    },
     "postgres-bytea": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
-    },
-    "postgres-date": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz",
-      "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g="
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+      "dev": true
     },
     "postgres-interval": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.2.tgz",
       "integrity": "sha512-fC3xNHeTskCxL1dC8KOtxXt7YeFmlbTYtn7ul8MkVERuTmf7pI4DrkAxcw3kh1fQ9uz4wQmd03a1mRiXUZChfQ==",
+      "dev": true,
       "requires": {
         "xtend": "^4.0.0"
       }
@@ -7586,17 +7551,14 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -7709,7 +7671,8 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -7749,7 +7712,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -8758,6 +8722,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -8766,12 +8731,14 @@
     "spdx-exceptions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -8780,12 +8747,14 @@
     "spdx-license-ids": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
     },
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
       "requires": {
         "through": "2"
       }
@@ -9217,7 +9186,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "2.0.5",
@@ -9511,6 +9481,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -9530,11 +9501,6 @@
       "requires": {
         "isexe": "^2.0.0"
       }
-    },
-    "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
     "which-pm-runs": {
       "version": "1.0.0",
@@ -9586,11 +9552,6 @@
       "requires": {
         "string-width": "^4.0.0"
       }
-    },
-    "window-size": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
     },
     "windows-release": {
       "version": "3.3.1",
@@ -9701,6 +9662,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -9710,6 +9672,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9718,6 +9681,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9728,6 +9692,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9803,12 +9768,14 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
     },
     "yallist": {
       "version": "3.1.1",
@@ -9821,113 +9788,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
       "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
       "dev": true
-    },
-    "yargs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
-      "integrity": "sha1-M1UUSXfQV1fbuG1uOOwFYSOzpm4=",
-      "requires": {
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "lodash.assign": "^4.2.0",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.2",
-        "which-module": "^1.0.0",
-        "window-size": "^0.2.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^3.2.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
-      "integrity": "sha1-UIE1XRnZ0MjF2BrakIy05tGGZk8=",
-      "requires": {
-        "camelcase": "^3.0.0",
-        "lodash.assign": "^4.1.0"
-      }
     },
     "yargs-unparser": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,7 @@
     "url": "https://github.com/davesag/sequelize-pg-utilities/issues"
   },
   "homepage": "https://github.com/davesag/sequelize-pg-utilities#readme",
-  "dependencies": {
-    "pgtools": "^0.3.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@stryker-mutator/core": "^3.3.1",
     "@stryker-mutator/javascript-mutator": "^3.3.1",
@@ -71,18 +69,23 @@
     "lint-staged": "^10.2.11",
     "mocha": "^8.0.1",
     "nyc": "^15.1.0",
+    "pg": "^8.3.0",
     "prettier": "^2.0.5",
     "proxyquire": "^2.1.3",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0",
     "snyk": "^1.363.0"
   },
+  "peerDependencies": {
+    "pg": ">= 6.4.2"
+  },
   "prettier": {
     "semi": false,
     "singleQuote": true,
     "proseWrap": "never",
     "arrowParens": "avoid",
-    "trailingComma": "none"
+    "trailingComma": "none",
+    "printWidth": 100
   },
   "lint-staged": {
     "**/*.{js,json,md}": [

--- a/src/configure.js
+++ b/src/configure.js
@@ -25,24 +25,14 @@ const configure = (
   { [env]: config },
   defaultDbName,
   logger = false,
-  {
-    pool: { validate } = {},
-    retry: { match, max } = {},
-    ...additionalOptions
-  } = {}
+  { pool: { validate } = {}, retry: { match, max } = {}, ...additionalOptions } = {}
 ) => {
   const parsedUrl = urlParser(process.env.DATABASE_URL)
 
-  const name =
-    parsedUrl.database ||
-    process.env.DB_NAME ||
-    config.database ||
-    defaultDbName
+  const name = parsedUrl.database || process.env.DB_NAME || config.database || defaultDbName
 
-  const user =
-    parsedUrl.username || process.env.DB_USER || config.username || null
-  const password =
-    parsedUrl.password || process.env.DB_PASS || config.password || null
+  const user = parsedUrl.username || process.env.DB_USER || config.username || null
+  const password = parsedUrl.password || process.env.DB_PASS || config.password || null
 
   const poolOptions = config.pool
     ? {
@@ -61,8 +51,7 @@ const configure = (
   const options = {
     host: parsedUrl.host || process.env.DB_HOST || config.host || 'localhost',
     port: parsedUrl.port || process.env.DB_PORT || config.port || 5432,
-    dialect:
-      parsedUrl.dialect || process.env.DB_TYPE || config.dialect || 'postgres',
+    dialect: parsedUrl.dialect || process.env.DB_TYPE || config.dialect || 'postgres',
     logging: logger, // this can be a logging function or false.
     pool: appendPoolOptions(poolOptions)
   }

--- a/src/createDb.js
+++ b/src/createDb.js
@@ -1,0 +1,26 @@
+const { Client } = require('pg')
+
+const DEFAULT_ADMIN_DB = 'postgres'
+const DUPLICATE_DATABASE = '42P04'
+
+const createDb = async (options, name) => {
+  const config = {
+    database: DEFAULT_ADMIN_DB,
+    ...options
+  }
+
+  return new Promise((resolve, reject) => {
+    const client = new Client(config)
+    client.on('drain', client.end.bind(client))
+    client.on('error', reject)
+    client.connect()
+
+    const sql = `CREATE DATABASE "${name}"`
+    return client
+      .query(sql)
+      .then(() => resolve(true))
+      .catch(err => (err && err.code === DUPLICATE_DATABASE ? resolve(false) : reject(err)))
+  })
+}
+
+module.exports = createDb

--- a/src/makeInitialiser.js
+++ b/src/makeInitialiser.js
@@ -1,5 +1,4 @@
-const pgtools = require('pgtools')
-
+const createDb = require('./createDb')
 const sleep = require('./sleep')
 const configure = require('./configure')
 const env = require('./env')
@@ -33,21 +32,13 @@ const makeInitialiser = (config, defaultDbName, logger, options) => {
       }
     }
 
-    try {
-      await pgtools.createdb(dbConfig, name)
-      return {
-        isNew: true,
-        message: `createdb created database '${name}'`
-      }
-    } catch (err) {
-      if (err.name && err.name === 'duplicate_database') {
-        return {
-          isNew: false,
-          message: `Database '${name}' already exists`
-        }
-      }
-      throw err
-    }
+    const dbNew = await createDb(dbConfig, name)
+
+    const message = dbNew
+      ? `createDb created database '${name}'`
+      : `Database '${name}' already exists`
+
+    return { dbNew, message }
   }
 
   const initialise = async (retries = MAX_RETRIES) => {

--- a/src/onlyDefined.js
+++ b/src/onlyDefined.js
@@ -5,8 +5,7 @@ const onlyDefined = data =>
     ? Object.keys(data).reduce((acc, elem) => {
         const value = data[elem]
         if (value !== undefined) {
-          if (Array.isArray(value))
-            acc[elem] = value.map(onlyDefined).filter(noUndefined)
+          if (Array.isArray(value)) acc[elem] = value.map(onlyDefined).filter(noUndefined)
           else if (typeof value === 'object') {
             const fValue = onlyDefined(value)
             if (Object.keys(fValue).length) acc[elem] = fValue

--- a/src/sleep.js
+++ b/src/sleep.js
@@ -1,4 +1,3 @@
-const sleep = forHowLong =>
-  new Promise(resolve => setTimeout(resolve, forHowLong))
+const sleep = forHowLong => new Promise(resolve => setTimeout(resolve, forHowLong))
 
 module.exports = sleep

--- a/test/unit/createDb.test.js
+++ b/test/unit/createDb.test.js
@@ -1,0 +1,85 @@
+const { expect } = require('chai')
+const { stub } = require('sinon')
+const proxyquire = require('proxyquire')
+
+describe('src/createDb', () => {
+  const on = stub()
+  const connect = stub()
+  const query = stub()
+
+  class Client {
+    end() {}
+  }
+
+  Client.prototype.on = on
+  Client.prototype.connect = connect
+  Client.prototype.query = query
+
+  const pg = { Client }
+  const createDb = proxyquire('../../src/createDb', {
+    pg: pg
+  })
+
+  const params = {
+    host: 'localhost',
+    port: '5432',
+    user: 'some-user',
+    password: 'shh-secret'
+  }
+
+  let result
+
+  const cleanup = () => {
+    on.resetHistory()
+    connect.resetHistory()
+    query.resetHistory()
+    result = undefined
+  }
+
+  context('when it creates a new database', () => {
+    before(async () => {
+      query.resolves()
+      result = await createDb(params)
+    })
+
+    after(cleanup)
+
+    it('returns the expected result', () => {
+      expect(result).to.equal(true)
+    })
+  })
+
+  context('when a database already exists', () => {
+    const err = { code: '42P04' }
+
+    before(async () => {
+      query.rejects(err)
+      result = await createDb(params)
+    })
+
+    after(cleanup)
+
+    it('returns the expected result', () => {
+      expect(result).to.equal(false)
+    })
+  })
+
+  context('when an error occurs', () => {
+    const err = { code: 'something else' }
+
+    before(async () => {
+      query.rejects(err)
+      try {
+        await createDb(params)
+      } catch (e) {
+        result = e
+      }
+    })
+
+    after(cleanup)
+
+    it('returns the expected result', () => {
+      expect(result).to.equal(err)
+    })
+  })
+})

--- a/test/unit/onlyDefined.test.js
+++ b/test/unit/onlyDefined.test.js
@@ -3,11 +3,7 @@ const { expect } = require('chai')
 const onlyDefined = require('../../src/onlyDefined')
 
 const original = {
-  array: [
-    { inner: 'w00t!', however: undefined },
-    undefined,
-    { outer: 'huzzah!' }
-  ],
+  array: [{ inner: 'w00t!', however: undefined }, undefined, { outer: 'huzzah!' }],
   here: 'is okay',
   test: undefined,
   otherTest: { nah: undefined }


### PR DESCRIPTION
- removed `pgtools` (resolves #30)
- make use of the `pg` library directly as a peer dependency as any project using this will already have `pg` as a dependency
- updated some other development dependencies
